### PR TITLE
check for global constant instead of accidentily autoloading

### DIFF
--- a/lib/cistern/formatter.rb
+++ b/lib/cistern/formatter.rb
@@ -4,9 +4,9 @@ module Cistern::Formatter
   autoload :Formatador, 'cistern/formatter/formatador'
 
   def self.default
-    if defined?(AwesomePrint)
+    if defined?(::AwesomePrint)
       Cistern::Formatter::AwesomePrint
-    elsif defined?(Formatador)
+    elsif defined?(::Formatador)
       Cistern::Formatter::Formatador
     else Cistern::Formatter::Default
     end


### PR DESCRIPTION
when checking for `AwesomePrint` in the Cistern scope, it was trying to autoload.

was causing:

```
LoadError: cannot load such file -- awesome_print
    from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/cistern-0.3.1/lib/cistern/formatter/awesome_print.rb:1:in `<top (required)>'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/cistern-0.3.1/lib/cistern/formatter.rb:8:in `default'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/cistern-0.3.1/lib/cistern.rb:25:in `formatter'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/cistern-0.3.1/lib/cistern/collection.rb:52:in `inspect'
```
