### PR TITLE
Array#to_s is an alias for #inspect

### DIFF
--- a/lib/cistern/collection.rb
+++ b/lib/cistern/collection.rb
@@ -10,7 +10,7 @@ class Cistern::Collection < Array
     end
   end
 
-  %w[first last size count to_s].each do |method|
+  %w[first last size count inspect].each do |method|
     define_method(method) do
       lazy_load unless @loaded
       super()


### PR DESCRIPTION
Previously caused weirdness when using core collections in a console

```
# before
client.environments # => []
client.environments.all # => [...]

# after
client.environments # => [...]
client.environments.all # => [...]
```

Should also consider not subclassing Array but storing it in an instance var and offering specific methods to operate on it. Theres a talk about how inheriting from core classes in mri can cause weirdness with special cases in the c code for certain class types. Also would mean methods not specifically handled would err rather than silently operate on the underlying Array object. Would also be able to include Enumerable, define #each with a lazy load, and get working lazy methods for everything else.
