### PR TITLE
Model fallback inspect should include identity

### DIFF
--- a/lib/cistern/model.rb
+++ b/lib/cistern/model.rb
@@ -7,7 +7,8 @@ class Cistern::Model
   def inspect
     if Cistern.formatter
       Cistern.formatter.call(self)
-    else super
+    else
+      "#<#{self.class} #{self.identity}"
     end
   end
 


### PR DESCRIPTION
Object#inspect isn't useful to fall back to
