### PR TITLE
Track attribute usage for coverage reporting

### DIFF
--- a/lib/cistern/coverage.rb
+++ b/lib/cistern/coverage.rb
@@ -1,0 +1,34 @@
+module Cistern::Coverage
+
+  unless Kernel.respond_to? :caller_locations
+    abort <<-ABORT
+Cannot enable Cistern coverage reporting
+
+Your ruby version ruby is: #{RUBY_VERSION rescue 'unknown'}
+`Kernel` does not have the required method `caller_locations`
+
+Try a newer ruby (should be > 2.0)
+    ABORT
+  end
+
+  # returns the first caller_locations entry before entries in `file`
+  def self.find_caller_before(file)
+    enum = caller_locations.each
+
+    call = nil
+
+    # seek to the first entry from within `file`
+    while(call = enum.next) do
+      break if call.path.end_with? file
+    end
+
+    # seek to the first entry thats not within `file`
+    while(call = enum.next) do
+      break unless call.path.end_with? file
+    end
+
+    # the call location that called in to `file`
+    call
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,5 +2,12 @@ require File.expand_path('../../lib/cistern', __FILE__)
 
 Bundler.require(:test)
 
-RSpec.configure do
+RSpec.configure do |c|
+  c.treat_symbols_as_metadata_keys_with_true_values = true
+
+  if Kernel.respond_to?(:caller_locations)
+    require File.expand_path('../../lib/cistern/coverage', __FILE__)
+  else
+    c.filter_run_excluding(:coverage)
+  end
 end


### PR DESCRIPTION
Includes Cistern::Coverage with helpers
