### PR TITLE
Provide consistent globals on Cistern::WaitFor

### DIFF
--- a/lib/cistern/wait_for.rb
+++ b/lib/cistern/wait_for.rb
@@ -5,12 +5,31 @@ module Cistern
     DEFAULT_TIMEOUT       = 180 # 3 minutes
     DEFAULT_POLL_INTERVAL = 10  # 10 seconds
 
-    def timeout; @timeout || DEFAULT_TIMEOUT; end
-    def timeout=(timeout); @timeout = timeout; end
-    def poll_interval; @poll_interval || DEFAULT_POLL_INTERVAL; end
-    def poll_interval=(poll_interval); @poll_interval = poll_interval; end
-    def timeout_error=(timeout_error); @timeout_error = timeout_error; end
-    def timeout_error; @timeout_error || self.const_defined?(:Timeout) && self.const_get(:Timeout) || ::Timeout::Error; end
+    # These are the actual stored global versions
+    class <<self
+      attr_writer :timeout
+      def timeout
+        @timeout ||= Cistern::WaitFor::DEFAULT_TIMEOUT
+      end
+
+      attr_writer :poll_interval
+      def poll_interval
+        @poll_interval ||= Cistern::WaitFor::DEFAULT_POLL_INTERVAL
+      end
+
+      attr_writer :timeout_error
+      def timeout_error
+        @timeout_error ||= self.const_defined?(:Timeout) && self.const_get(:Timeout) || ::Timeout::Error
+      end
+    end
+
+    # Call out to the global versions
+    def timeout; Cistern::WaitFor.timeout; end
+    def timeout=(t); Cistern::WaitFor.timeout = t; end
+    def poll_interval; Cistern::WaitFor.poll_interval; end
+    def poll_interval=(p); Cistern::WaitFor.poll_interval = p; end
+    def timeout_error; Cistern::WaitFor.timeout_error; end
+    def timeout_error=(e); Cistern::WaitFor.timeout_error = e; end
 
     def wait_for(timeout = self.timeout, interval = self.poll_interval, &block)
       duration = 0


### PR DESCRIPTION
Previously each class/object extending Cistern::WaitFor would end up
with its own set of timeout, polling interval, error class variables.
This change leaves the existing API in place (`Cistern.timeout`,
`SomeClient.new.timeout`) and proxies these both to the global
`Cistern::Waitfor.timeout`.

This change allows setting `Cistern.poll_interval = 0` in tests and have
it take effect, where previously only certain things looked at
`Cistern.poll_interval` and others would continue to use the default.
