### PR TITLE
service is not required to determine #missing_attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+- 2.3.0
 - 2.2
 - 1.9
 bundler_args: "--without development"

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :test do
   gem "pry-nav"
   gem "rake"
   gem "rspec", "~> 3.3"
+  gem "listen", "~> 3.0.5"
   gem "redis-namespace", "~> 1.4", "< 1.5"
   gem "codeclimate-test-reporter", require: false
 end

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -268,7 +268,7 @@ module Cistern::Attributes
     protected
 
     def missing_attributes(args)
-      ([:service] | args).select { |arg| send("#{arg}").nil? }
+      args.select { |arg| send("#{arg}").nil? }
     end
 
     def changed!(attribute, from, to)

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -1,8 +1,11 @@
 module Cistern::Attributes
+  PROTECTED_METHODS = [:cistern, :service, :identity, :collection].freeze
+  TRUTHY = ['true', '1'].freeze
+
   def self.parsers
     @parsers ||= {
       array:   ->(v, _) { [*v] },
-      boolean: ->(v, _) { %w(true 1).include?(v.to_s.downcase) },
+      boolean: ->(v, _) { TRUTHY.include?(v.to_s.downcase) },
       float:   ->(v, _) { v && v.to_f },
       integer: ->(v, _) { v && v.to_i },
       string:  ->(v, opts) { (opts[:allow_nil] && v.nil?) ? v : v.to_s },
@@ -189,7 +192,7 @@ module Cistern::Attributes
     end
 
     def merge_attributes(new_attributes = {})
-      protected_methods  = (Cistern::Model.instance_methods - [:service, :identity, :collection])
+      protected_methods  = (Cistern::Model.instance_methods - PROTECTED_METHODS)
       ignored_attributes = self.class.ignored_attributes
       class_attributes   = self.class.attributes
       class_aliases      = self.class.aliases


### PR DESCRIPTION
leftover from fog-core extraction