### PR TITLE
deprecate #service, use #cistern

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ while living on a `Prayer`
 ```ruby
 class Foo::GetBar < Foo::Prayer
   def real
-    service.request.get("/wing")
+    cistern.request.get("/wing")
   end
 end
 ```
@@ -109,7 +109,7 @@ fake.is_a?(Foo::Client::Mock) # true
 
 Requests are defined by subclassing `#{service}::Request`.
 
-* `service` represents the associated `Foo::Client` instance.
+* `cistern` represents the associated `Foo::Client` instance.
 
 ```ruby
 class Foo::Client::GetBar < Foo::Client::Request
@@ -127,11 +127,11 @@ end
 Foo::Client.new.get_bar # "i'm real"
 ```
 
-The `#service_method` function allows you to specify the name of the generated method.
+The `#cistern_method` function allows you to specify the name of the generated method.
 
 ```ruby
 class Foo::Client::GetBars < Foo::Client::Request
-  service_method :get_all_the_bars
+  cistern_method :get_all_the_bars
 
   def real(params)
     "all the bars"
@@ -150,7 +150,7 @@ Foo::Client.requests # => [Foo::Client::GetBars, Foo::Client::GetBar]
 
 ### Models
 
-* `service` represents the associated `Foo::Client` instance.
+* `cistern` represents the associated `Foo::Client` instance.
 * `collection` represents the related collection (if applicable)
 * `new_record?` checks if `identity` is present
 * `requires(*requirements)` throws `ArgumentError` if an attribute matching a requirement isn't set
@@ -182,7 +182,7 @@ class Foo::Client::Bar < Foo::Client::Model
     params  = {
       "id" => self.identity
     }
-    self.service.destroy_bar(params).body["request"]
+    self.cistern.destroy_bar(params).body["request"]
   end
 
   def save
@@ -196,11 +196,11 @@ class Foo::Client::Bar < Foo::Client::Model
     }
 
     if new_record?
-      merge_attributes(service.create_bar(params).body["bar"])
+      merge_attributes(cistern.create_bar(params).body["bar"])
     else
       requires :identity
 
-      merge_attributes(service.update_bar(params).body["bar"])
+      merge_attributes(cistern.update_bar(params).body["bar"])
     end
   end
 end
@@ -209,7 +209,7 @@ end
 ### Collection
 
 * `model` tells Cistern which class is contained within the collection.
-* `service` is the associated `Foo::Client` instance
+* `cistern` is the associated `Foo::Client` instance
 * `attribute` specifications on collections are allowed. use `merge_attributes`
 * `load` consumes an Array of data and constructs matching `model` instances
 
@@ -221,7 +221,7 @@ class Foo::Client::Bars < Foo::Client::Collection
   model Foo::Client::Bar
 
   def all(params = {})
-    response = service.get_bars(params)
+    response = cistern.get_bars(params)
 
     data = response.body
 
@@ -235,11 +235,11 @@ class Foo::Client::Bars < Foo::Client::Collection
     }
     params.merge!("location" => options[:location]) if options.key?(:location)
 
-    service.requests.new(service.discover_bar(params).body["request"])
+    cistern.requests.new(cistern.discover_bar(params).body["request"])
   end
 
   def get(id)
-    if data = service.get_bar("id" => id).body["bar"]
+    if data = cistern.get_bar("id" => id).body["bar"]
       new(data)
     else
       nil

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Cistern helps you consistently build your API clients and faciliates building mo
 
 ### Custom Architecture
 
-By default a service's `Request`, `Collection`, and `Model` are all classes. In Cistern ~> 3.0, the default will be modules.
+By default a service's `Request`, `Collection`, and `Model` are all classes. In cistern `~> 3.0`, the default will be modules.
 
 You can modify your client's architecture to be forwards compatible by using `Cistern::Client.with`
 

--- a/lib/cistern/client.rb
+++ b/lib/cistern/client.rb
@@ -1,11 +1,11 @@
 module Cistern::Client
   module Collections
     def collections
-      service.collections
+      cistern.collections
     end
 
     def requests
-      service.requests
+      cistern.requests
     end
   end
 
@@ -43,19 +43,35 @@ module Cistern::Client
     interface_callback = (:class == interface) ? :inherited : :included
 
     unless klass.name
-      fail ArgumentError, "can't turn anonymous class into a Cistern service"
+      fail ArgumentError, "can't turn anonymous class into a Cistern cistern"
     end
 
     klass.class_eval <<-EOS, __FILE__, __LINE__
       module Collections
         include ::Cistern::Client::Collections
 
-        def service
+        def cistern
+          Cistern.deprecation(
+            '#cistern is deprecated.  Please use #cistern',
+            caller[0]
+          )
+          #{klass.name}
+        end
+
+        def cistern
           #{klass.name}
         end
       end
 
-      def self.service
+      def self.cistern
+        Cistern.deprecation(
+          '#cistern is deprecated.  Please use #cistern',
+          caller[0]
+        )
+        #{klass.name}
+      end
+
+      def self.cistern
         #{klass.name}
       end
 
@@ -71,21 +87,29 @@ module Cistern::Client
 
       #{interface} #{model_class}
         def self.#{interface_callback}(klass)
-          service.models << klass
+          cistern.models << klass
 
           klass.send(:include, ::Cistern::Model)
 
           super
         end
 
-        def self.service
+        def self.cistern
+          Cistern.deprecation(
+            '#cistern is deprecated.  Please use #cistern',
+            caller[0]
+          )
+          #{klass.name}
+        end
+
+        def self.cistern
           #{klass.name}
         end
       end
 
       #{interface} #{singular_class}
         def self.#{interface_callback}(klass)
-          service.singularities << klass
+          cistern.singularities << klass
 
           klass.send(:include, ::Cistern::Singular)
 
@@ -93,6 +117,14 @@ module Cistern::Client
         end
 
         def self.service
+          Cistern.deprecation(
+            '#service is deprecated.  Please use #cistern',
+            caller[0]
+          )
+          #{klass.name}
+        end
+
+        def self.cistern
           #{klass.name}
         end
       end
@@ -105,12 +137,20 @@ module Cistern::Client
           klass.send(:extend, Cistern::Collection::ClassMethods)
           klass.send(:include, Cistern::Attributes::InstanceMethods)
 
-          service.collections << klass
+          cistern.collections << klass
 
           super
         end
 
         def self.service
+          Cistern.deprecation(
+            '#service is deprecated.  Please use #cistern',
+            caller[0]
+          )
+          #{klass.name}
+        end
+
+        def self.cistern
           #{klass.name}
         end
       end
@@ -119,13 +159,21 @@ module Cistern::Client
         include ::Cistern::Request
 
         def self.service
+          Cistern.deprecation(
+            '#service is deprecated.  Please use #cistern',
+            caller[0]
+          )
+          #{klass.name}
+        end
+
+        def self.cistern
           #{klass.name}
         end
 
         def self.#{interface_callback}(klass)
           klass.extend(::Cistern::Request::ClassMethods)
 
-          service.requests << klass
+          cistern.requests << klass
 
           super
         end
@@ -219,31 +267,31 @@ module Cistern::Client
       return true if @_setup
 
       requests.each do |klass|
-        name = klass.service_method ||
+        name = klass.cistern_method ||
                Cistern::String.camelize(Cistern::String.demodulize(klass.name))
 
-        Cistern::Request.service_request(self, klass, name)
+        Cistern::Request.cistern_request(self, klass, name)
       end
 
       collections.each do |klass|
-        name = klass.service_method ||
+        name = klass.cistern_method ||
                Cistern::String.underscore(klass.name.gsub("#{self.name}::", '').gsub('::', ''))
 
-        Cistern::Collection.service_collection(self, klass, name)
+        Cistern::Collection.cistern_collection(self, klass, name)
       end
 
       models.each do |klass|
-        name = klass.service_method ||
+        name = klass.cistern_method ||
                Cistern::String.underscore(klass.name.gsub("#{self.name}::", '').gsub('::', ''))
 
-        Cistern::Model.service_model(self, klass, name)
+        Cistern::Model.cistern_model(self, klass, name)
       end
 
       singularities.each do |klass|
-        name = klass.service_method ||
+        name = klass.cistern_method ||
                Cistern::String.underscore(klass.name.gsub("#{self.name}::", '').gsub('::', ''))
 
-        Cistern::Singular.service_singular(self, klass, name)
+        Cistern::Singular.cistern_singular(self, klass, name)
       end
 
       @_setup = true

--- a/lib/cistern/collection.rb
+++ b/lib/cistern/collection.rb
@@ -5,23 +5,40 @@ module Cistern::Collection
     :keep_if, :pop, :shift, :delete_at, :compact
   ].to_set # :nodoc:
 
-  def self.service_collection(service, klass, name)
-    service.const_get(:Collections).module_eval <<-EOS, __FILE__, __LINE__
+  def self.cistern_collection(cistern, klass, name)
+    cistern.const_get(:Collections).module_eval <<-EOS, __FILE__, __LINE__
       def #{name}(attributes={})
-        #{klass.name}.new(attributes.merge(service: self))
+        #{klass.name}.new(attributes.merge(cistern: self))
       end
     EOS
   end
 
-  attr_accessor :records, :loaded, :service
+  attr_accessor :records, :loaded, :cistern
+
+  def service
+    Cistern.deprecation(
+      '#service is deprecated.  Please use #cistern',
+      caller[0]
+    )
+    @cistern
+  end
 
   module ClassMethods
     def model(new_model = nil)
       @_model ||= new_model
     end
 
+    # @deprecated Use {#cistern_method} instead
     def service_method(name = nil)
-      @_service_method ||= name
+      Cistern.deprecation(
+        '#service_method is deprecated.  Please use #cistern_method',
+        caller[0]
+      )
+      @_cistern_method ||= name
+    end
+
+    def cistern_method(name = nil)
+      @_cistern_method ||= name
     end
   end
 
@@ -80,7 +97,7 @@ module Cistern::Collection
     model.new(
       {
         collection: self,
-        service: service
+        cistern: cistern,
       }.merge(attributes)
     )
   end

--- a/lib/cistern/collection.rb
+++ b/lib/cistern/collection.rb
@@ -15,6 +15,14 @@ module Cistern::Collection
 
   attr_accessor :records, :loaded, :cistern
 
+  def service=(service)
+    Cistern.deprecation(
+      '#service= is deprecated.  Please use #cistern=',
+      caller[0]
+    )
+    @cistern = service
+  end
+
   def service
     Cistern.deprecation(
       '#service is deprecated.  Please use #cistern',

--- a/lib/cistern/model.rb
+++ b/lib/cistern/model.rb
@@ -7,21 +7,38 @@ module Cistern::Model
     klass.send(:extend, Cistern::Model::ClassMethods)
   end
 
-  def self.service_model(service, klass, name)
-    service.const_get(:Collections).module_eval <<-EOS, __FILE__, __LINE__
+  def self.cistern_model(cistern, klass, name)
+    cistern.const_get(:Collections).module_eval <<-EOS, __FILE__, __LINE__
       def #{name}(attributes={})
-        #{klass.name}.new(attributes.merge(service: self))
+    #{klass.name}.new(attributes.merge(cistern: self))
       end
     EOS
   end
 
   module ClassMethods
+    # @deprecated Use {#cistern_method} instead
     def service_method(name = nil)
-      @_service_method ||= name
+      Cistern.deprecation(
+        '#service_method is deprecated.  Please use #cistern_method',
+        caller[0]
+      )
+      @_cistern_method ||= name
+    end
+
+    def cistern_method(name = nil)
+      @_cistern_method ||= name
     end
   end
 
-  attr_accessor :collection, :service
+  attr_accessor :collection, :cistern
+
+  def service
+    Cistern.deprecation(
+      '#service is deprecated.  Please use #cistern',
+      caller[0]
+    )
+    @cistern
+  end
 
   def inspect
     Cistern.formatter.call(self)
@@ -67,15 +84,23 @@ module Cistern::Model
     end
   end
 
-  def wait_for(timeout = service_class.timeout, interval = service_class.poll_interval, &block)
-    service_class.wait_for(timeout, interval) { reload && block.call(self) }
+  def wait_for(timeout = cistern_class.timeout, interval = cistern_class.poll_interval, &block)
+    cistern_class.wait_for(timeout, interval) { reload && block.call(self) }
   end
 
-  def wait_for!(timeout = service_class.timeout, interval = service_class.poll_interval, &block)
-    service_class.wait_for!(timeout, interval) { reload && block.call(self) }
+  def wait_for!(timeout = cistern_class.timeout, interval = cistern_class.poll_interval, &block)
+    cistern_class.wait_for!(timeout, interval) { reload && block.call(self) }
   end
 
   def service_class
-    service ? service.class : Cistern
+    Cistern.deprecation(
+      '#service_class is deprecated.  Please use #cistern_class',
+      caller[0]
+    )
+    cistern ? cistern.class : Cistern
+  end
+
+  def cistern_class
+    cistern ? cistern.class : Cistern
   end
 end

--- a/lib/cistern/model.rb
+++ b/lib/cistern/model.rb
@@ -32,6 +32,14 @@ module Cistern::Model
 
   attr_accessor :collection, :cistern
 
+  def service=(service)
+    Cistern.deprecation(
+      '#service= is deprecated.  Please use #cistern=',
+      caller[0]
+    )
+    @cistern = service
+  end
+
   def service
     Cistern.deprecation(
       '#service is deprecated.  Please use #cistern',

--- a/lib/cistern/request.rb
+++ b/lib/cistern/request.rb
@@ -6,13 +6,13 @@ module Cistern::Request
 
     cistern::Mock.module_eval <<-EOS, __FILE__, __LINE__
       def #{name}(*args)
-    #{klass}.new(self)._mock(*args)
+        #{klass}.new(self)._mock(*args)
       end
     EOS
 
     cistern::Real.module_eval <<-EOS, __FILE__, __LINE__
       def #{name}(*args)
-    #{klass}.new(self)._real(*args)
+        #{klass}.new(self)._real(*args)
       end
     EOS
   end

--- a/lib/cistern/request.rb
+++ b/lib/cistern/request.rb
@@ -1,31 +1,56 @@
 module Cistern::Request
-  def self.service_request(service, klass, name)
-    unless klass.name
+  def self.cistern_request(cistern, klass, name)
+    unless klass.name || klass.cistern_method
       fail ArgumentError, "can't turn anonymous class into a Cistern request"
     end
 
-    service::Mock.module_eval <<-EOS, __FILE__, __LINE__
+    cistern::Mock.module_eval <<-EOS, __FILE__, __LINE__
       def #{name}(*args)
-        #{klass}.new(self)._mock(*args)
+    #{klass}.new(self)._mock(*args)
       end
     EOS
 
-    service::Real.module_eval <<-EOS, __FILE__, __LINE__
+    cistern::Real.module_eval <<-EOS, __FILE__, __LINE__
       def #{name}(*args)
-        #{klass}.new(self)._real(*args)
+    #{klass}.new(self)._real(*args)
       end
     EOS
   end
 
-  attr_reader :service
+  def self.service_request(*args)
+    Cistern.deprecation(
+      '#service_request is deprecated.  Please use #cistern_request',
+      caller[0]
+    )
+    cistern_request(*args)
+  end
 
-  def initialize(service)
-    @service = service
+  attr_reader :cistern
+
+  def service
+    Cistern.deprecation(
+      '#service is deprecated.  Please use #cistern',
+      caller[0]
+    )
+    @cistern
+  end
+
+  def initialize(cistern)
+    @cistern = cistern
   end
 
   module ClassMethods
+    # @deprecated Use {#cistern_method} instead
     def service_method(name = nil)
-      @_service_method ||= name
+      Cistern.deprecation(
+        '#service_method is deprecated.  Please use #cistern_method',
+        caller[0]
+      )
+      @_cistern_method ||= name
+    end
+
+    def cistern_method(name = nil)
+      @_cistern_method ||= name
     end
   end
 end

--- a/lib/cistern/singular.rb
+++ b/lib/cistern/singular.rb
@@ -1,8 +1,8 @@
 module Cistern::Singular
-  def self.service_singular(service, klass, name)
-    service.const_get(:Collections).module_eval <<-EOS, __FILE__, __LINE__
+  def self.cistern_singular(cistern, klass, name)
+    cistern.const_get(:Collections).module_eval <<-EOS, __FILE__, __LINE__
       def #{name}(attributes={})
-        #{klass.name}.new(attributes.merge(service: self))
+    #{klass.name}.new(attributes.merge(cistern: self))
       end
     EOS
   end
@@ -13,7 +13,15 @@ module Cistern::Singular
     klass.send(:extend, Cistern::Model::ClassMethods)
   end
 
-  attr_accessor :service
+  attr_accessor :cistern
+
+  def service
+    Cistern.deprecation(
+      '#service is deprecated.  Please use #cistern',
+      caller[0]
+    )
+    @cistern
+  end
 
   def inspect
     Cistern.formatter.call(self)

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe 'Cistern::Collection' do
-  class SampleService < Cistern::Service
+  class SampleService
+    include Cistern::Client
   end
 
   class Drug < SampleService::Model
@@ -18,7 +19,7 @@ describe 'Cistern::Collection' do
   end
 
   class Tacs < SampleService::Collection
-    service_method :toes
+    cistern_method :toes
   end
 
   it 'should generate a default collection method' do
@@ -63,5 +64,20 @@ describe 'Cistern::Collection' do
 
   it 'should ==' do
     Drugs.new.all == Drugs.new.all
+  end
+
+  describe 'deprecation', :deprecated do
+    class DeprecatedCollectionService
+      include Cistern::Client
+    end
+
+    it 'responds to #service' do
+      class DeprecationCollection < DeprecatedCollectionService::Collection
+        service_method :deprecator
+      end
+
+      sample = DeprecatedCollectionService.new.deprecator
+      expect(sample.service).to eq(sample.cistern)
+    end
   end
 end

--- a/spec/mock_data_spec.rb
+++ b/spec/mock_data_spec.rb
@@ -6,7 +6,7 @@ describe 'mock data' do
     end
 
     def mock(diagnosis)
-      service.data.store(:diagnosis, service.data.fetch(:diagnosis) + [diagnosis])
+      cistern.data.store(:diagnosis, cistern.data.fetch(:diagnosis) + [diagnosis])
     end
   end
 
@@ -15,7 +15,7 @@ describe 'mock data' do
     end
 
     def mock(treatment)
-      service.data[:treatments] += [treatment]
+      cistern.data[:treatments] += [treatment]
     end
   end
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -55,7 +55,7 @@ describe 'Cistern::Model' do
     end
 
     class SpecificModelService::Jimbob < SpecificModelService::Model
-      service_method :john_boy
+      cistern_method :john_boy
     end
 
     expect(SpecificModelService.new).not_to respond_to(:jimbob)
@@ -244,6 +244,21 @@ describe 'Cistern::Model' do
     it "should store how many times an attribute's reader is called" do
       expect(CoverageSpec.attributes[:used][:coverage_hits]).to eq(2)
       expect(CoverageSpec.attributes[:unused][:coverage_hits]).to eq(0)
+    end
+  end
+
+  describe 'deprecation', :deprecated do
+    class DeprecatedModelService
+      include Cistern::Client
+    end
+
+    it 'responds to #service' do
+      class Deprecation < DeprecatedModelService::Model
+        service_method :deprecator
+      end
+
+      sample = DeprecatedModelService.new.deprecator
+      expect(sample.service).to eq(sample.cistern)
     end
   end
 end

--- a/spec/singular_spec.rb
+++ b/spec/singular_spec.rb
@@ -6,8 +6,8 @@ describe 'Cistern::Singular' do
     attribute :count, type: :number
 
     def fetch_attributes
-      # test that initialize waits for service to be defined
-      fail 'missing service' unless service
+      # test that initialize waits for cistern to be defined
+      fail 'missing cistern' unless cistern
 
       @counter ||= 0
       @counter += 1
@@ -17,6 +17,13 @@ describe 'Cistern::Singular' do
 
   it 'should work' do
     expect(Sample.new.sample_singular.name).to eq('amazing')
+  end
+
+  describe 'deprecation', :deprecated do
+    it 'responds to #service' do
+      sample = Sample.new.sample_singular
+      expect(sample.service).to eq(sample.cistern)
+    end
   end
 
   it 'should reload' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,12 +8,18 @@ Dir[File.expand_path('../{support,shared,matchers,fixtures}/*.rb', __FILE__)].ea
 
 Bundler.require(:test)
 
-Cistern.deprecation_warnings = false
+Cistern.deprecation_warnings = !!ENV['DEBUG']
 
-RSpec.configure do |c|
+RSpec.configure do |rspec|
   if Kernel.respond_to?(:caller_locations)
     require File.expand_path('../../lib/cistern/coverage', __FILE__)
   else
-    c.filter_run_excluding(:coverage)
+    rspec.filter_run_excluding(:coverage)
+  end
+  rspec.around(:each, :deprecated) do |example|
+    original_value = Cistern.deprecation_warnings?
+    Cistern.deprecation_warnings = false
+    example.run
+    Cistern.deprecation_warnings = original_value
   end
 end


### PR DESCRIPTION
* `cistern` is less likely to cause semantic conflicts
* Fixes #50 