### PR TITLE
use #stage_attributes to make #dirty_attributes available on #update

### DIFF
--- a/lib/cistern/model.rb
+++ b/lib/cistern/model.rb
@@ -31,8 +31,10 @@ module Cistern::Model
     merge_attributes(attributes)
   end
 
+  # Merge #attributes and call {#save}.  Valid and change attributes are available in {#dirty_attributes}
+  # @param attributes [Hash]
   def update(attributes)
-    merge_attributes(attributes)
+    stage_attributes(attributes)
     save
   end
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -8,11 +8,11 @@ describe 'Cistern::Model' do
       attribute :properties
 
       def save
-        attributes
+        dirty_attributes
       end
     end
 
-    it 'should merge and save attributes' do
+    it 'should merge and save dirty attributes' do
       model = UpdateSpec.new(name: 'steve')
       model.save
 


### PR DESCRIPTION
* currently updates are forced to send the entire object representation via `attributes`
* enable users to send just modified attributes via `dirty_attributes`