### PR TITLE
officially deprecate class interface

### DIFF
--- a/lib/cistern/client.rb
+++ b/lib/cistern/client.rb
@@ -42,6 +42,13 @@ module Cistern::Client
     interface = options[:interface] || :class
     interface_callback = (:class == interface) ? :inherited : :included
 
+    if interface == :class
+      Cistern.deprecation(
+        %q{class' interface is deprecated. Use `include Cistern::Client.with(interface: :module). See https://github.com/lanej/cistern#custom-architecture},
+        caller[2],
+      )
+    end
+
     unless klass.name
       fail ArgumentError, "can't turn anonymous class into a Cistern service"
     end


### PR DESCRIPTION
* module interface will be the default in cistern `> 3.0`