### PR TITLE
Tweaks for Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,22 +39,24 @@ end
 
 ### Custom Architecture
 
-Other options include `:collection`, `:request`, and `:model`.  This options define the name of module or class interface for the service component.
+When configuring your client, you can use `:collection`, `:request`, and `:model` options to define the name of module or class interface for the service component.
 
-If `Request` is to reserved for a model, then the `Request` component name can be remapped to `Prayer`
+For example: if you'd like `Request` is to be used for a model, then the `Request` component name can be remapped to `Prayer`
 
 For example:
 
 ```ruby
 class Foo::Client
-  include Cistern::Client.with(request: "Prayer")
+  include Cistern::Client.with(interface: :modules, request: "Prayer")
 end
 ```
 
 allows a model named `Request` to exist
 
 ```ruby
-class Foo::Request < Foo::Model
+class Foo::Request
+  include Foo::Client::Model
+
   identity :jovi
 end
 ```
@@ -62,7 +64,9 @@ end
 while living on a `Prayer`
 
 ```ruby
-class Foo::GetBar < Foo::Prayer
+class Foo::GetBar
+  include Foo::Client::Prayer
+
   def real
     cistern.request.get("/wing")
   end

--- a/README.md
+++ b/README.md
@@ -37,42 +37,6 @@ class Foo::GetBar
 end
 ```
 
-### Custom Architecture
-
-When configuring your client, you can use `:collection`, `:request`, and `:model` options to define the name of module or class interface for the service component.
-
-For example: if you'd like `Request` is to be used for a model, then the `Request` component name can be remapped to `Prayer`
-
-For example:
-
-```ruby
-class Foo::Client
-  include Cistern::Client.with(interface: :modules, request: "Prayer")
-end
-```
-
-allows a model named `Request` to exist
-
-```ruby
-class Foo::Request
-  include Foo::Client::Model
-
-  identity :jovi
-end
-```
-
-while living on a `Prayer`
-
-```ruby
-class Foo::GetBar
-  include Foo::Client::Prayer
-
-  def real
-    cistern.request.get("/wing")
-  end
-end
-```
-
 
 ### Service
 
@@ -356,6 +320,42 @@ bar.save
 bar.dirty?           # => false
 bar.changed          # => {}
 bar.dirty_attributes # => {}
+```
+
+### Custom Architecture
+
+When configuring your client, you can use `:collection`, `:request`, and `:model` options to define the name of module or class interface for the service component.
+
+For example: if you'd like `Request` is to be used for a model, then the `Request` component name can be remapped to `Prayer`
+
+For example:
+
+```ruby
+class Foo::Client
+  include Cistern::Client.with(interface: :modules, request: "Prayer")
+end
+```
+
+allows a model named `Request` to exist
+
+```ruby
+class Foo::Request
+  include Foo::Client::Model
+
+  identity :jovi
+end
+```
+
+while living on a `Prayer`
+
+```ruby
+class Foo::GetBar
+  include Foo::Client::Prayer
+
+  def real
+    cistern.request.get("/wing")
+  end
+end
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -9,11 +9,15 @@ Cistern helps you consistently build your API clients and faciliates building mo
 
 ## Usage
 
-### Custom Architecture
+### Notice: Cistern 3.0
 
-By default a service's `Request`, `Collection`, and `Model` are all classes. In cistern `~> 3.0`, the default will be modules.
+Cistern 3.0 will change the way Cistern interacts with your `Request`, `Collection` and `Model` classes.
 
-You can modify your client's architecture to be forwards compatible by using `Cistern::Client.with`
+Prior to 3.0, your `Request`, `Collection` and `Model` classes would have inherited from `<service>::Client::Request`, `<service>::Client::Collection` and `<service>::Client::Model` classes, respectively.
+
+In cistern `~> 3.0`, the default will be for `Request`, `Collection` and `Model` classes to instead include their respective `<service>::Client` modules.
+
+If you want to be forwards-compatible today, you can configure your client by using `Cistern::Client.with`
 
 ```ruby
 class Foo::Client
@@ -32,6 +36,8 @@ class Foo::GetBar
   end
 end
 ```
+
+### Custom Architecture
 
 Other options include `:collection`, `:request`, and `:model`.  This options define the name of module or class interface for the service component.
 


### PR DESCRIPTION
I was *super* confused by the language around 3.0 & `interface: :modules` in the readme. This is (hopefully? arguably? debatably?) easier to follow.