### PR TITLE
fix(attributes): allow string types to be nil

### DIFF
--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -8,7 +8,7 @@ module Cistern::Attributes
       boolean: ->(v, _) { TRUTHY.include?(v.to_s.downcase) },
       float:   ->(v, _) { v && v.to_f },
       integer: ->(v, _) { v && v.to_i },
-      string:  ->(v, opts) { (opts[:allow_nil] && v.nil?) ? v : v.to_s },
+      string:  ->(v, _) { v && v.to_s },
       time:    ->(v, _) { v.is_a?(Time) ? v : v && Time.parse(v.to_s) },
     }
   end

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -75,7 +75,7 @@ describe Cistern::Attributes, 'parsing' do
   it 'should parse string' do
     expect(TypeSpec.new(name: 1).name).to eq('1')
     expect(TypeSpec.new(name: "b").name).to eq('b')
-    expect(TypeSpec.new(name: nil).name).to eq("")
+    expect(TypeSpec.new(name: nil).name).to eq(nil)
   end
 
   it 'should allow nils in string types' do


### PR DESCRIPTION
previous behavior was to convert all values #to_s (including nil).  New behavior is to `allow_nil` by default.

BREAKING CHANGE ?

this will break installations that rely on the nil to empty string
conversions.