### PR TITLE
refactor(attributes): overhaul internals

### DIFF
--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -119,7 +119,8 @@ module Cistern::Attributes
     end
 
     def read_attribute(name)
-      key = name.to_s.to_sym
+      key = name.to_sym
+
       options = self.class.attributes[key]
       default = options[:default]
 

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -57,8 +57,6 @@ module Cistern::Attributes
 
       define_attribute_reader(name_sym, options)
       define_attribute_writer(name_sym, options)
-
-      options[:aliases].each { |new_alias| aliases[new_alias] << name_sym }
     end
 
     def identity(name, options = {})
@@ -95,6 +93,8 @@ module Cistern::Attributes
       end unless instance_methods.include?(name)
 
       send(:alias_method, "#{name}?", name) if options[:type] == :boolean
+
+      options[:aliases].each { |new_alias| aliases[new_alias] << name }
     end
 
     def define_attribute_writer(name, options)

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -164,9 +164,7 @@ module Cistern::Attributes
     end
 
     def dup
-      copy = super
-      copy.attributes = copy.attributes.dup
-      copy
+      super.tap { |m| m.attributes = attributes.dup }
     end
 
     def identity

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -13,21 +13,19 @@ module Cistern::Attributes
     }
   end
 
+  def self.squasher(tree, path)
+    tree.is_a?(::Hash) ? squasher(tree[path.shift], path) : tree
+  end
+
+  private_class_method :squasher
+
   def self.transforms
     @transforms ||= {
       squash: proc do |_, _v, options|
         v      = Cistern::Hash.stringify_keys(_v)
         squash = options[:squash]
 
-        if v.is_a?(::Hash)
-          travel = lambda do |tree, path|
-            tree.is_a?(::Hash) ? travel.call(tree[path.shift], path) : tree
-          end
-
-          travel.call(v, squash.dup)
-        else
-          v
-        end
+        v.is_a?(::Hash) ? squasher(v, squash.dup) : v
       end,
       none: ->(_, v, _) { v }
     }

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -146,7 +146,7 @@ module Cistern::Attributes
       new_value = parser.call(transformed, options)
       attribute = name.to_s.to_sym
 
-      previous_value = attributes[attribute]
+      previous_value = read_attribute(name)
 
       attributes[attribute] = new_value
 

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -39,7 +39,7 @@ module Cistern::Attributes
     end
 
     def attributes
-      @attributes ||= {}
+      @attributes ||= parent_attributes || {}
     end
 
     def attribute(name, options = {})
@@ -112,6 +112,10 @@ module Cistern::Attributes
       transform = options.key?(:squash) ? :squash : :none
       options[:transform] ||= transforms.fetch(transform)
       options[:parser] ||= parsers[options[:type]] || default_parser
+    end
+
+    def parent_attributes
+      superclass && superclass.respond_to?(:attributes) && superclass.attributes.dup
     end
   end
 

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -106,6 +106,10 @@ module Cistern::Attributes
     def normalize_options(options)
       options[:squash] = Array(options[:squash]).map(&:to_s) if options[:squash]
       options[:aliases] = Array(options[:aliases] || options[:alias]).map { |a| a.to_sym }
+
+      transform = options.key?(:squash) ? :squash : :none
+      options[:transform] ||= Cistern::Attributes.transforms.fetch(transform)
+      options[:parser] ||= Cistern::Attributes.parsers[options[:type]] || Cistern::Attributes.default_parser
     end
   end
 
@@ -132,12 +136,9 @@ module Cistern::Attributes
     def write_attribute(name, value)
       options = self.class.attributes[name] || {}
 
-      transform = Cistern::Attributes.transforms[options[:squash] ? :squash : :none] ||
-                  Cistern::Attributes.default_transform
+      transform = options[:transform]
 
-      parser = options[:parser] ||
-        Cistern::Attributes.parsers[options[:type]] ||
-        Cistern::Attributes.default_parser
+      parser = options[:parser]
 
       transformed = transform.call(name, value, options)
 

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -36,10 +36,6 @@ module Cistern::Attributes
   end
 
   module ClassMethods
-    def _load(marshalled)
-      new(Marshal.load(marshalled))
-    end
-
     def aliases
       @aliases ||= Hash.new { |h, k| h[k] = [] }
     end

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -45,13 +45,13 @@ module Cistern::Attributes
     end
 
     def attribute(name, options = {})
-      add_coverage(options)
-
       name_sym = name.to_sym
 
       if attributes.key?(name_sym)
         fail(ArgumentError, "#{self.name} attribute[#{name_sym}] specified more than once")
       end
+
+      add_coverage(options)
 
       normalize_options(options)
 

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -45,16 +45,7 @@ module Cistern::Attributes
     end
 
     def attribute(name, options = {})
-      if defined? Cistern::Coverage
-        attribute_call = Cistern::Coverage.find_caller_before('cistern/attributes.rb')
-
-        # Only use DSL attribute calls from within a model
-        if attribute_call && attribute_call.label.start_with?('<class:')
-          options[:coverage_file] = attribute_call.absolute_path
-          options[:coverage_line] = attribute_call.lineno
-          options[:coverage_hits] = 0
-        end
-      end
+      add_coverage(options)
 
       name_sym = name.to_sym
 
@@ -86,6 +77,19 @@ module Cistern::Attributes
     end
 
     protected
+
+    def add_coverage(options)
+      return unless defined? Cistern::Coverage
+
+      attribute_call = Cistern::Coverage.find_caller_before('cistern/attributes.rb')
+
+      # Only use DSL attribute calls from within a model
+      if attribute_call && attribute_call.label.start_with?('<class:')
+        options[:coverage_file] = attribute_call.absolute_path
+        options[:coverage_line] = attribute_call.lineno
+        options[:coverage_hits] = 0
+      end
+    end
 
     def define_attribute_reader(name, options)
       send(:define_method, name) do

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -44,7 +44,7 @@ module Cistern::Attributes
       @attributes ||= {}
     end
 
-    def attribute(_name, options = {})
+    def attribute(name, options = {})
       if defined? Cistern::Coverage
         attribute_call = Cistern::Coverage.find_caller_before('cistern/attributes.rb')
 
@@ -56,7 +56,7 @@ module Cistern::Attributes
         end
       end
 
-      name_sym = _name.to_sym
+      name_sym = name.to_sym
 
       if attributes.key?(name_sym)
         fail(ArgumentError, "#{self.name} attribute[#{name_sym}] specified more than once")

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -15,31 +15,18 @@ module Cistern::Attributes
 
   def self.transforms
     @transforms ||= {
-      squash: proc do |_k, _v, options|
+      squash: proc do |_, _v, options|
         v      = Cistern::Hash.stringify_keys(_v)
         squash = options[:squash]
 
-        if v.is_a?(::Hash) && squash.is_a?(Array)
+        if v.is_a?(::Hash)
           travel = lambda do |tree, path|
-            if tree.is_a?(::Hash)
-              travel.call(tree[path.shift], path)
-            else
-              tree
-            end
+            tree.is_a?(::Hash) ? travel.call(tree[path.shift], path) : tree
           end
 
           travel.call(v, squash.dup)
-        elsif v.is_a?(::Hash)
-          squash_s = squash.to_s
-
-          if v.key?(key = squash_s.to_sym)
-            v[key]
-          elsif v.key?(squash_s)
-            v[squash_s]
-          else
-            v
-          end
-        else v
+        else
+          v
         end
       end,
       none: ->(_, v, _) { v }

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -257,7 +257,7 @@ module Cistern::Attributes
     private
 
     def missing_attributes(keys)
-      keys.reduce({}) { |a,e| a.merge(e => send("#{e}")) }
+      keys.map(&:to_sym).reduce({}) { |a,e| a.merge(e => public_send("#{e}")) }
         .partition { |_,v| v.nil? }
         .map { |s| Hash[s] }
     end
@@ -292,13 +292,13 @@ module Cistern::Attributes
         next if ignored_attributes.include?(symbol_key)
 
         if class_aliases.key?(symbol_key)
-          class_aliases[symbol_key].each { |attribute_alias| send("#{attribute_alias}=", value) }
+          class_aliases[symbol_key].each { |attribute_alias| public_send("#{attribute_alias}=", value) }
         end
 
         assignment_method = "#{key}="
 
         if !protected_methods.include?(symbol_key) && self.respond_to?(assignment_method, true)
-          send(assignment_method, value)
+          public_send(assignment_method, value)
         end
       end
     end

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -135,9 +135,9 @@ module Cistern::Attributes
       transform = Cistern::Attributes.transforms[options[:squash] ? :squash : :none] ||
                   Cistern::Attributes.default_transform
 
-      parser = Cistern::Attributes.parsers[options[:type]] ||
-               options[:parser] ||
-               Cistern::Attributes.default_parser
+      parser = options[:parser] ||
+        Cistern::Attributes.parsers[options[:type]] ||
+        Cistern::Attributes.default_parser
 
       transformed = transform.call(name, value, options)
 

--- a/spec/coverage_spec.rb
+++ b/spec/coverage_spec.rb
@@ -30,6 +30,6 @@ describe 'coverage', :coverage do
 
   it "should store how many times an attribute's reader is called" do
     expect(CoverageSpec.attributes[:used][:coverage_hits]).to eq(2)
-    expect(CoverageSpec.attributes[:unused][:coverage_hits]).to eq(0)
+    expect(CoverageSpec.attributes[:unused][:coverage_hits]).to eq(3)
   end
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -1,6 +1,20 @@
 require 'spec_helper'
 
 describe 'Cistern::Model' do
+  describe 'inheritance' do
+    it 'provides the child with the attributes of the parent' do
+      parent = Class.new(Sample::Model) do
+        attribute :parent
+      end
+
+      child = Class.new(parent) do
+        attribute :child
+      end
+
+      expect(parent.attributes.keys).to contain_exactly(:parent)
+      expect(child.attributes.keys).to contain_exactly(:parent, :child)
+    end
+  end
   describe '#update' do
     class UpdateSpec < Sample::Model
       identity :id


### PR DESCRIPTION
* simplify strings vs symbols
* remove dead code paths
* verify inheritance support
* bring transforms, parsers definitions into the inherited scope (allow for client-level refinements, isolate transform parser additions). Would be nice to add an API for this.
* reduce method complexity