### PR TITLE
refactor(singular): a collection-less model

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,54 @@ post.update(author_id: 1) #=> calls #save with #dirty_attributes == { 'author_id
 post.author_id #=> 1
 ```
 
+### Singular
+
+Singular resources do not have an associated collection and the model contains the `get` and`save` methods.
+
+For instance:
+
+```ruby
+class Blog::PostData
+  include Blog::Singular
+
+  attribute :post_id, type: :integer
+  attribute :upvotes, type: :integer
+  attribute :views, type: :integer
+  attribute :rating, type: :float
+
+  def get
+    response = cistern.get_post_data(post_id)
+    merge_attributes(response.body['data'])
+  end
+  
+  def save
+    response = cistern.update_post_data(post_id, dirty_attributes)
+    merge_attributes(response.data['data'])
+  end
+end
+```
+
+Singular resources often hang off of other models or collections.
+
+```ruby
+class Blog::Post
+  include Cistern::Model
+
+  identity :id, type: :integer
+
+  def data
+    cistern.post_data(post_id: identity).load
+  end
+end
+```
+
+They are special cases of Models and have similar interfaces.
+
+```ruby
+post.data.views #=> nil
+post.data.update(views: 3)
+post.data.views #=> 3
+```
 
 
 ### Collection

--- a/lib/cistern/singular.rb
+++ b/lib/cistern/singular.rb
@@ -31,16 +31,14 @@ module Cistern::Singular
 
   def initialize(options)
     merge_attributes(options)
-    reload
+  end
+
+  def fetch(*args)
+    reload(*args)
+    self
   end
 
   def reload
-    new_attributes = fetch_attributes
-
-    merge_attributes(new_attributes) if new_attributes
-  end
-
-  def fetch_attributes
-    fail NotImplementedError
+    raise NotImplementedError
   end
 end

--- a/lib/cistern/singular.rb
+++ b/lib/cistern/singular.rb
@@ -1,5 +1,5 @@
 module Cistern::Singular
-  include Cistern::HashSupport
+  include Cistern::Model
 
   def self.cistern_singular(cistern, klass, name)
     cistern.const_get(:Collections).module_eval <<-EOS, __FILE__, __LINE__
@@ -10,35 +10,23 @@ module Cistern::Singular
   end
 
   def self.included(klass)
+    super
+
     klass.send(:extend, Cistern::Attributes::ClassMethods)
     klass.send(:include, Cistern::Attributes::InstanceMethods)
     klass.send(:extend, Cistern::Model::ClassMethods)
   end
 
-  attr_accessor :cistern
-
-  def service
-    Cistern.deprecation(
-      '#service is deprecated.  Please use #cistern',
-      caller[0]
-    )
-    @cistern
-  end
-
-  def inspect
-    Cistern.formatter.call(self)
-  end
-
-  def initialize(options)
-    merge_attributes(options)
-  end
-
-  def fetch(*args)
-    reload(*args)
+  def collection
     self
   end
 
-  def reload
+  def get
     raise NotImplementedError
+  end
+
+  def reload
+    get
+    self
   end
 end

--- a/lib/cistern/singular.rb
+++ b/lib/cistern/singular.rb
@@ -4,7 +4,7 @@ module Cistern::Singular
   def self.cistern_singular(cistern, klass, name)
     cistern.const_get(:Collections).module_eval <<-EOS, __FILE__, __LINE__
       def #{name}(attributes={})
-    #{klass.name}.new(attributes.merge(cistern: self))
+        #{klass.name}.new(attributes.merge(cistern: self))
       end
     EOS
   end

--- a/lib/cistern/singular.rb
+++ b/lib/cistern/singular.rb
@@ -29,4 +29,6 @@ module Cistern::Singular
     get
     self
   end
+
+  alias load reload
 end

--- a/spec/singular_spec.rb
+++ b/spec/singular_spec.rb
@@ -1,31 +1,35 @@
 require 'spec_helper'
 
 describe 'Cistern::Singular' do
-  class SampleSingular < Sample::Singular
+  class Settings < Sample::Singular
     attribute :name
     attribute :count, type: :number
 
-    def fetch_attributes
+    def reload
       # test that initialize waits for cistern to be defined
       fail 'missing cistern' unless cistern
 
       @counter ||= 0
       @counter += 1
-      { name: 'amazing', count: @counter }
+      merge_attributes(name: 'amazing', count: @counter)
     end
   end
 
+  let!(:service) { Sample.new }
+
   describe 'deprecation', :deprecated do
     it 'responds to #service' do
-      sample = Sample.new.sample_singular
+      sample = service.settings.fetch
+
       expect(sample.service).to eq(sample.cistern)
     end
   end
 
-  it 'reloads on initialize' do
-    singular = Sample.new.sample_singular
-    expect(singular.name).to eq('amazing')
+  it 'reloads' do
+    singular = service.settings(count: 0)
 
     expect { singular.reload }.to change(singular, :count).by(1)
   end
+
+  it 'updates'
 end

--- a/spec/singular_spec.rb
+++ b/spec/singular_spec.rb
@@ -5,10 +5,7 @@ describe 'Cistern::Singular' do
     attribute :name
     attribute :count, type: :number
 
-    def reload
-      # test that initialize waits for cistern to be defined
-      fail 'missing cistern' unless cistern
-
+    def get
       @counter ||= 0
       @counter += 1
       merge_attributes(name: 'amazing', count: @counter)
@@ -19,7 +16,7 @@ describe 'Cistern::Singular' do
 
   describe 'deprecation', :deprecated do
     it 'responds to #service' do
-      sample = service.settings.fetch
+      sample = service.settings.get
 
       expect(sample.service).to eq(sample.cistern)
     end

--- a/spec/singular_spec.rb
+++ b/spec/singular_spec.rb
@@ -2,13 +2,21 @@ require 'spec_helper'
 
 describe 'Cistern::Singular' do
   class Settings < Sample::Singular
-    attribute :name
+    attribute :name, type: :string
     attribute :count, type: :number
 
+    def save
+      result = @@settings = attributes.merge(dirty_attributes)
+
+      merge_attributes(result)
+    end
+
     def get
-      @counter ||= 0
-      @counter += 1
-      merge_attributes(name: 'amazing', count: @counter)
+      settings = @@settings ||= {}
+      settings[:count] ||= 0
+      settings[:count] += 1
+
+      merge_attributes(settings)
     end
   end
 
@@ -28,5 +36,8 @@ describe 'Cistern::Singular' do
     expect { singular.reload }.to change(singular, :count).by(1)
   end
 
-  it 'updates'
+  it 'updates' do
+    service.settings.update(name: 6)
+    expect(service.settings.get.name).to eq('6')
+  end
 end

--- a/spec/singular_spec.rb
+++ b/spec/singular_spec.rb
@@ -24,7 +24,7 @@ describe 'Cistern::Singular' do
 
   describe 'deprecation', :deprecated do
     it 'responds to #service' do
-      sample = service.settings.get
+      sample = service.settings.load
 
       expect(sample.service).to eq(sample.cistern)
     end
@@ -38,6 +38,6 @@ describe 'Cistern::Singular' do
 
   it 'updates' do
     service.settings.update(name: 6)
-    expect(service.settings.get.name).to eq('6')
+    expect(service.settings.load.name).to eq('6')
   end
 end


### PR DESCRIPTION
* [x] model API compliance
* [x] documentation

This is technically a breaking change but for an undocumented feature that no one is using ?