### PR TITLE
add request_attributes, dirty_request_attributes helpers

### DIFF
--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -265,6 +265,18 @@ module Cistern::Attributes
       @changes ||= {}
     end
 
+    def request_attributes(set = attributes)
+      set.inject({}) do |a,(k,v)|
+        aliases = self.class.attributes[k.to_sym][:aliases]
+        aliases << k if aliases.empty?
+        aliases.each_with_object(a) { |n,r| r[n.to_s] = v }
+      end
+    end
+
+    def dirty_request_attributes
+      request_attributes(dirty_attributes)
+    end
+
     private
 
     def missing_attributes(keys)

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -1,43 +1,45 @@
 require 'spec_helper'
 
 describe Cistern::Attributes, 'requires' do
-  class RequireSpec < Sample::Model
-    identity :id
-    attribute :name, type: :string
-    attribute :type
-  end
+  subject {
+    Class.new(Sample::Model) do
+      identity :id
+      attribute :name, type: :string
+      attribute :type
+    end
+  }
 
   it 'raises if required attributes are not present' do
     expect {
-      Sample.new.require_spec.requires :name
+      subject.new.requires :name
     }.to raise_exception(ArgumentError, /name is required/)
 
     data = { name: '1' }
-    return_value = Sample.new.require_spec(data).requires :name
+    return_value = subject.new(data).requires :name
 
     expect(return_value).to eq(data)
 
     expect {
-      Sample.new.require_spec.requires :name, :type
+      subject.new.requires :name, :type
     }.to raise_exception(ArgumentError, /name and type are required/)
 
     data = { name: '1', type: 'sample' }
-    return_values = Sample.new.require_spec(data).requires :name, :type
+    return_values = subject.new(data).requires :name, :type
     expect(return_values).to eq(data)
   end
 
   it 'raises if a required attribute attribute is not present' do
     expect {
-      Sample.new.require_spec.requires_one :name, :type
+      subject.new.requires_one :name, :type
     }.to raise_exception(ArgumentError, /name or type are required/)
 
     data = { name: '1' }
-    return_value = Sample.new.require_spec(data).requires_one :name, :type
+    return_value = subject.new(data).requires_one :name, :type
 
     expect(return_value).to eq(data)
 
     data = { name: '1', type: 'sample' }
-    return_values = Sample.new.require_spec(data).requires_one :name, :type
+    return_values = subject.new(data).requires_one :name, :type
     expect(return_values).to eq(data)
   end
 end

--- a/spec/coverage_spec.rb
+++ b/spec/coverage_spec.rb
@@ -1,35 +1,39 @@
 require 'spec_helper'
 
 describe 'coverage', :coverage do
-  class CoverageSpec < Sample::Model
-    identity :id
+  subject {
+    class Sample::Coverage < Sample::Model
+      identity :id
 
-    attribute :used, type: :string
-    attribute :unused, type: :string
-  end
+      attribute :used, type: :string
+      attribute :unused, type: :string
+    end
 
-  let!(:obj) { CoverageSpec.new(used: 'foo', unused: 'bar') }
+    Sample::Coverage
+  }
+
+  let!(:model) { subject.new(used: 'foo', unused: 'bar') }
 
   before(:each) do
-    CoverageSpec.attributes[:used][:coverage_hits] = 0
-    expect(obj.used).to eq('foo') # once
-    expect(obj.used).to eq('foo') # twice
+    subject.attributes[:used][:coverage_hits] = 0
+    expect(model.used).to eq('foo') # once
+    expect(model.used).to eq('foo') # twice
   end
 
   it 'should store the file path where the attribute was defined' do
-    expect(CoverageSpec.attributes[:used][:coverage_file]).to eq(__FILE__)
-    expect(CoverageSpec.attributes[:unused][:coverage_file]).to eq(__FILE__)
+    expect(subject.attributes[:used][:coverage_file]).to eq(__FILE__)
+    expect(subject.attributes[:unused][:coverage_file]).to eq(__FILE__)
   end
 
   it 'should store the line number where the attribute was defined' do
     src_lines = File.read(__FILE__).lines
 
-    expect(src_lines[CoverageSpec.attributes[:used][:coverage_line] - 1]).to match(/attribute :used/)
-    expect(src_lines[CoverageSpec.attributes[:unused][:coverage_line] - 1]).to match(/attribute :unused/)
+    expect(src_lines[subject.attributes[:used][:coverage_line] - 1]).to match(/attribute :used/)
+    expect(src_lines[subject.attributes[:unused][:coverage_line] - 1]).to match(/attribute :unused/)
   end
 
   it "should store how many times an attribute's reader is called" do
-    expect(CoverageSpec.attributes[:used][:coverage_hits]).to eq(2)
-    expect(CoverageSpec.attributes[:unused][:coverage_hits]).to eq(3)
+    expect(subject.attributes[:used][:coverage_hits]).to eq(2)
+    expect(subject.attributes[:unused][:coverage_hits]).to eq(1)
   end
 end

--- a/spec/dirty_spec.rb
+++ b/spec/dirty_spec.rb
@@ -1,19 +1,21 @@
 require 'spec_helper'
 
 describe 'Cistern::Model#dirty' do
-  class DirtySpec < Sample::Model
-    identity :id
+  subject {
+    Class.new(Sample::Model) do
+      identity :id
 
-    attribute :name
-    attribute :properties, type: :array
+      attribute :name
+      attribute :properties, type: :array
 
-    def save
-      merge_attributes(attributes)
+      def save
+        merge_attributes(attributes)
+      end
     end
-  end
+  }
 
   it 'should mark a existing record as dirty' do
-    model = DirtySpec.new(id: 1, name: 'steve')
+    model = subject.new(id: 1, name: 'steve')
     expect(model.changed).to be_empty
 
     expect do

--- a/spec/mock_data_spec.rb
+++ b/spec/mock_data_spec.rb
@@ -1,23 +1,25 @@
 require 'spec_helper'
 
 describe 'mock data' do
-  class Diagnosis < Sample::Request
-    def real(diagnosis)
+  before {
+    class Sample::Diagnosis < Sample::Request
+      def real(diagnosis)
+      end
+
+      def mock(diagnosis)
+        cistern.data.store(:diagnosis, cistern.data.fetch(:diagnosis) + [diagnosis])
+      end
     end
 
-    def mock(diagnosis)
-      cistern.data.store(:diagnosis, cistern.data.fetch(:diagnosis) + [diagnosis])
-    end
-  end
+    class Sample::Treat < Sample::Request
+      def real(treatment)
+      end
 
-  class Treat < Sample::Request
-    def real(treatment)
+      def mock(treatment)
+        cistern.data[:treatments] += [treatment]
+      end
     end
-
-    def mock(treatment)
-      cistern.data[:treatments] += [treatment]
-    end
-  end
+  }
 
   shared_examples 'mock_data#backend' do |backend, options|
     it 'should store mock data' do

--- a/spec/singular_spec.rb
+++ b/spec/singular_spec.rb
@@ -1,24 +1,26 @@
 require 'spec_helper'
 
 describe 'Cistern::Singular' do
-  class Settings < Sample::Singular
-    attribute :name, type: :string
-    attribute :count, type: :number
+  before {
+    class Sample::Settings < Sample::Singular
+      attribute :name, type: :string
+      attribute :count, type: :number
 
-    def save
-      result = @@settings = attributes.merge(dirty_attributes)
+      def save
+        result = @@settings = attributes.merge(dirty_attributes)
 
-      merge_attributes(result)
+        merge_attributes(result)
+      end
+
+      def get
+        settings = @@settings ||= {}
+        settings[:count] ||= 0
+        settings[:count] += 1
+
+        merge_attributes(settings)
+      end
     end
-
-    def get
-      settings = @@settings ||= {}
-      settings[:count] ||= 0
-      settings[:count] += 1
-
-      merge_attributes(settings)
-    end
-  end
+  }
 
   let!(:service) { Sample.new }
 

--- a/spec/support/service.rb
+++ b/spec/support/service.rb
@@ -1,1 +1,8 @@
+RSpec.configure do |config|
+  config.before(:each) {
+    Object.send(:remove_const, :Sample) if Object.constants.include?(:Sample)
+    class Sample; include Cistern::Client; end
+  }
+end
+
 class Sample; include Cistern::Client; end

--- a/spec/wait_for_spec.rb
+++ b/spec/wait_for_spec.rb
@@ -1,67 +1,70 @@
 require 'spec_helper'
 
-class WaitForModel < Sample::Model
-  identity :id
-
-  attribute :name
-end
-
-class WaitForModels < Sample::Collection
-  model WaitForModel
-
-  def get(_identity)
-    self
-  end
-end
-
-describe 'Cistern#wait_for' do
-  it 'should return false if timeout exceeded' do
-    expect(Cistern.wait_for(0, 0) { false }).to be_falsey
-  end
-end
-
-describe 'Cistern#wait_for!' do
-  it 'should raise if timeout exceeded' do
-    expect { Cistern.wait_for!(0, 0) { false } }.to raise_exception(Cistern::Timeout)
-  end
-end
-
-describe 'Cistern::Model#wait_for!' do
+describe 'Cistern::WaitFor' do
   let(:service) { Sample.new }
-  let(:model)   { service.wait_for_models.new(identity: 1) }
+  before {
+    class Sample::Wait < Sample::Model
+      identity :id
 
-  it 'should raise if timeout exceeded' do
-    expect { model.wait_for!(0, 0) { false } }.to raise_exception(Sample::Timeout)
-  end
-end
+      attribute :name
+    end
 
-describe 'WaitForModel#timeout' do
-  let(:service) { Sample.new }
-  let(:model)   { service.wait_for_models.new(identity: 1) }
+    class Sample::Waits < Sample::Collection
+      model Sample::Wait
 
-  it 'should use service-specific timeout in #wait_for' do
-    service.class.timeout = 0.1
-    service.class.poll_interval = 0
+      def get(_identity)
+        self
+      end
+    end
+  }
 
-    elapsed = 0
-
-    Timeout.timeout(2) do
-      expect do
-        model.wait_for! { sleep(0.2); elapsed += 0.2; elapsed > 0.2 }
-      end.to raise_exception(Sample::Timeout)
+  describe 'Cistern#wait_for' do
+    it 'should return false if timeout exceeded' do
+      expect(Cistern.wait_for(0, 0) { false }).to be_falsey
     end
   end
 
-  it 'should favor explicit timeout' do
-    service.class.timeout = 1
-    service.class.poll_interval = 0
+  describe 'Cistern#wait_for!' do
+    it 'should raise if timeout exceeded' do
+      expect { Cistern.wait_for!(0, 0) { false } }.to raise_exception(Cistern::Timeout)
+    end
+  end
 
-    elapsed = 0
+  describe 'Cistern::Model#wait_for!' do
+    let(:model) { service.waits.new(identity: 1) }
 
-    Timeout.timeout(2) do
-      expect do
-        model.wait_for!(0.1) { sleep(0.2); elapsed += 0.2; elapsed > 0.2 }
-      end.to raise_exception(Sample::Timeout)
+    it 'should raise if timeout exceeded' do
+      expect { model.wait_for!(0, 0) { false } }.to raise_exception(Sample::Timeout)
+    end
+  end
+
+  describe 'WaitForModel#timeout' do
+    let(:model) { service.waits.new(identity: 1) }
+
+    it 'should use service-specific timeout in #wait_for' do
+      service.class.timeout = 0.1
+      service.class.poll_interval = 0
+
+      elapsed = 0
+
+      Timeout.timeout(2) do
+        expect do
+          model.wait_for! { sleep(0.2); elapsed += 0.2; elapsed > 0.2 }
+        end.to raise_exception(Sample::Timeout)
+      end
+    end
+
+    it 'should favor explicit timeout' do
+      service.class.timeout = 1
+      service.class.poll_interval = 0
+
+      elapsed = 0
+
+      Timeout.timeout(2) do
+        expect do
+          model.wait_for!(0.1) { sleep(0.2); elapsed += 0.2; elapsed > 0.2 }
+        end.to raise_exception(Sample::Timeout)
+      end
     end
   end
 end


### PR DESCRIPTION
processes aliases in reverse, enabling easy request-model and model-request attribute conversions