### PR TITLE
fix(model): #has_many is not loaded without records present

### DIFF
--- a/lib/cistern/associations.rb
+++ b/lib/cistern/associations.rb
@@ -29,7 +29,8 @@ module Cistern::Associations
       collection = instance_exec(&scope)
       records = attributes[name_sym] || []
 
-      collection.load(records)
+      collection.load(records) if records.any?
+      collection
     end
 
     define_method writer_method do |models|

--- a/lib/cistern/collection.rb
+++ b/lib/cistern/collection.rb
@@ -55,6 +55,7 @@ module Cistern::Collection
   alias_method :build, :initialize
 
   def initialize(attributes = {})
+    @loaded = false
     merge_attributes(attributes)
   end
 

--- a/spec/associations_spec.rb
+++ b/spec/associations_spec.rb
@@ -113,6 +113,21 @@ describe Cistern::Associations do
       expect(subject.new(associate_id: 2).associates.all).to eq(expected)
     end
 
+    it 'does not consider the associated collection loaded without records' do
+      model = subject.new(associate_id: 2)
+      model.associates = []
+
+      expect(model.associates.loaded).to eq(false)
+    end
+
+    it 'considers the associated collection loaded with records' do
+      model = subject.new(associate_id: 2)
+      model.associates = Sample::Associates.new(associate_id: 2).load([{id: 3}])
+
+      expect(model.associates.loaded).to eq(true)
+      expect(model.associates.records).to contain_exactly(Sample::Associate.new(id: 3))
+    end
+
     describe '{has_many}=' do
       it 'accepts models' do
         model = subject.new(associate_id: 2)


### PR DESCRIPTION
previous behavior, a collection is returned with `loaded=true` preventing lazy loading despite having no records.