### PR TITLE
feature: allow using `super` to override association methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,14 +405,12 @@ tag.creator = blogs.author.get(name: 'phil')
 tag.attributes[:creator] #=> { 'id' => 2, 'name' => 'phil' }
 ```
 
-Foreign keys can be updated with with the association writer by aliasing the original writer and accessing the
-underlying attributes.
+Foreign keys can be updated by overriding the association writer.
 
 ```ruby
 Blog::Tag.class_eval do
-  alias cistern_creator= creator=
   def creator=(creator)
-    self.cistern_creator = creator
+    super
     self.author_id = attributes[:creator][:id]
   end
 end

--- a/lib/cistern/associations.rb
+++ b/lib/cistern/associations.rb
@@ -6,7 +6,7 @@ module Cistern::Associations
       @association_overlay ||= const_set(:Associations, Module.new)
     end
 
-    klass.include(klass.association_overlay)
+    klass.send(:include, klass.association_overlay)
 
     super
   end

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -55,8 +55,8 @@ module Cistern::Attributes
 
       attributes[name_sym] = options
 
-      define_attribute_reader(name_sym, options)
-      define_attribute_writer(name_sym, options)
+      define_attribute_reader(name_sym, options) unless options[:reader] == false
+      define_attribute_writer(name_sym, options) unless options[:writer] == false
 
       name_sym
     end

--- a/spec/associations_spec.rb
+++ b/spec/associations_spec.rb
@@ -80,11 +80,28 @@ describe Cistern::Associations do
         expect(sample.attributes[:associate]).to eq(id: 2)
       end
 
-      it 'allows for overrides' do
+      it 'allows for aliased overrides' do
         subject.class_eval do
           alias cistern_associate= associate=
           def associate=(associate)
             self.cistern_associate = associate
+            self.associate_id = attributes[:associate][:id]
+          end
+        end
+
+        sample = subject.new(id: 1, associate_id: 3)
+
+        belongs_to = Sample::Associate.new(id: 2)
+
+        expect {
+          sample.associate = belongs_to
+        }.to change(sample, :associate_id).to(2)
+      end
+
+      it 'allows for overrides using super' do
+        subject.class_eval do
+          def associate=(associate)
+            super
             self.associate_id = attributes[:associate][:id]
           end
         end

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -226,6 +226,24 @@ describe Cistern::Attributes, 'parsing' do
     expect(subject.new(default: 'now im a different squash').default).to eq('now im a different squash')
   end
 
+  it 'can skip reader generation' do
+    subject.class_eval do
+      attribute :default, reader: false
+    end
+
+    expect(subject.new).not_to respond_to(:default)
+    expect(subject.new).to respond_to(:default=)
+  end
+
+  it 'can skip writer generation' do
+    subject.class_eval do
+      attribute :default, writer: false
+    end
+
+    expect(subject.new).to respond_to(:default)
+    expect(subject.new).not_to respond_to(:default=)
+  end
+
   context 'allowing the same alias for multiple attributes' do
     before {
       subject.class_eval do


### PR DESCRIPTION
Before coming up with a sleek way to update local attributes when setting association values, removing the necessity to `alias` a method allows for a much cleaner solution.

```ruby
belongs_to :author do
  cistern.authors.get(author_id)
end

def author=(author)
  super
  self.author_id = attributes[:author][:id]
end
```

This gives every resource it's own `::Association` module where the readers/writers live.