### PR TITLE
feature: add #clone_attributes

### DIFF
--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -125,8 +125,8 @@ module Cistern::Attributes
   end
 
   module InstanceMethods
-    def dump
-      Marshal.dump(attributes)
+    def clone_attributes
+      Marshal.load Marshal.dump(attributes)
     end
 
     def read_attribute(name)

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -1,5 +1,28 @@
 require 'spec_helper'
 
+describe Cistern::Attributes, '#clone_attributes' do
+  subject { Class.new(Sample::Model) }
+
+  it 'marshals the source attributes' do
+    subject.class_eval do
+      attribute :name
+      attribute :number
+      attribute :serial_number
+    end
+
+    model = subject.new(name: 'steve', number: 1, serial_number: 34)
+
+    cloned_attributes = model.clone_attributes
+
+    expect(cloned_attributes).to eq(model.attributes)
+
+    model.number = 3
+
+    expect(cloned_attributes[:number]).to eq(1)
+  end
+
+end
+
 describe Cistern::Attributes, '#request_attributes' do
   subject { Class.new(Sample::Model) }
 


### PR DESCRIPTION
this is useful when a request clones an existing model

BREAKING CHANGE

removes #dump, which was of little use