### PR TITLE
Add support for a Date type.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem "rspec", "~> 3.3"
   gem "listen", "~> 3.0.5"
   gem "redis-namespace", "~> 1.4", "< 1.5"
-  gem "codeclimate-test-reporter", require: false
+  gem "codeclimate-test-reporter", "< 1.0", require: false
 end
 
 group :formatters do

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Cistern attributes are designed to make your model flexible and developer friend
 	model.merge_attributes("post" => 1)
 	model.post_id #=> 1
 	```
-* `:type` automatically casts the attribute do the specified type. 
+* `:type` automatically casts the attribute do the specified type. Supported types: `array`, `boolean`, `date`, `float`, `integer`, `string`, `time`.
 	```ruby
 	attribute :private_ips, type: :array
 

--- a/gemfiles/ruby_lt_2.0.gemfile
+++ b/gemfiles/ruby_lt_2.0.gemfile
@@ -13,7 +13,7 @@ group :test do
   gem "rspec", "~> 3.3"
   gem "listen", "~> 3.0.5"
   gem "redis-namespace", "~> 1.4", "< 1.5"
-  gem "codeclimate-test-reporter", :require => false
+  gem "codeclimate-test-reporter", "< 1.0", :require => false
 end
 
 group :formatters do

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -7,6 +7,7 @@ module Cistern::Attributes
       @parsers ||= {
         array:   ->(v, _) { [*v] },
         boolean: ->(v, _) { TRUTHY.include?(v.to_s.downcase) },
+        date:    ->(v, _) { v.is_a?(Date) ? v : v && Date.parse(v.to_s) },
         float:   ->(v, _) { v && v.to_f },
         integer: ->(v, _) { v && v.to_i },
         string:  ->(v, _) { v && v.to_s },

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -157,6 +157,17 @@ describe Cistern::Attributes, 'parsing' do
     expect(subject.new(attributes: 'x').adam_attributes).to eq('x')
   end
 
+  it 'should parse date' do
+    subject.class_eval do
+      attribute :start_date, type: :date
+    end
+
+    date = Date.today
+    start_date = subject.new(start_date: date.to_s).start_date
+    expect(start_date).to be_a(Date)
+    expect(start_date.iso8601).to eq(date.iso8601)
+  end
+
   it 'should parse time' do
     subject.class_eval do
       attribute :created_at, type: :time

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -191,6 +191,16 @@ describe Cistern::Attributes, 'parsing' do
     expect(subject.new(list: 'item').list).to eq(['item'])
   end
 
+  it 'should parse an integer' do
+    subject.class_eval do
+      attribute :int, type: :integer
+    end
+
+    expect(subject.new(int: '42.5').int).to eq(42)
+    expect(subject.new(int: '42').int).to eq(42)
+    expect(subject.new(int: 42).int).to eq(42)
+  end
+
   it 'should parse a float' do
     subject.class_eval do
       attribute :floater, type: :float


### PR DESCRIPTION
While the `:time` attribute type will parse plain old dates it doesn't work for updating or creating records that require a vanilla date.

* add `date` attribute parser
* add a test for integer parsing
* add documentation for the supported types.