### PR TITLE
Freeze string literals with the magic comment

### DIFF
--- a/lib/cistern.rb
+++ b/lib/cistern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cistern/version'
 
 # stdlib

--- a/lib/cistern/associations.rb
+++ b/lib/cistern/associations.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Cistern::Associations
 
   def self.extended(klass)

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cistern::Attributes
   PROTECTED_METHODS = [:cistern, :service, :identity, :collection].freeze
   TRUTHY = ['true', '1'].freeze

--- a/lib/cistern/client.rb
+++ b/lib/cistern/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cistern::Client
   module Collections
     def collections

--- a/lib/cistern/collection.rb
+++ b/lib/cistern/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cistern::Collection
   include Cistern::HashSupport
 

--- a/lib/cistern/coverage.rb
+++ b/lib/cistern/coverage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cistern::Coverage
   unless Kernel.respond_to? :caller_locations
     abort <<-ABORT

--- a/lib/cistern/data.rb
+++ b/lib/cistern/data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cistern::Data
   def self.extended(klass)
     klass.send(:extend, ClassMethods)

--- a/lib/cistern/data/hash.rb
+++ b/lib/cistern/data/hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Cistern::Data::Hash
   Cistern::Data.backends[:hash] = self
 

--- a/lib/cistern/data/redis.rb
+++ b/lib/cistern/data/redis.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Cistern::Data::Redis
   Cistern::Data.backends[:redis] = self
 

--- a/lib/cistern/formatter.rb
+++ b/lib/cistern/formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cistern::Formatter
   autoload :AwesomePrint, 'cistern/formatter/awesome_print'
   autoload :Formatador,   'cistern/formatter/formatador'

--- a/lib/cistern/formatter/awesome_print.rb
+++ b/lib/cistern/formatter/awesome_print.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'awesome_print'
 
 module Cistern::Formatter::AwesomePrint

--- a/lib/cistern/formatter/awesome_print.rb
+++ b/lib/cistern/formatter/awesome_print.rb
@@ -30,13 +30,13 @@ module AwesomePrint::Cistern
   #------------------------------------------------------------------------------
   def awesome_cistern_model(object)
     data = object.attributes.keys.sort.each_with_object({}) { |e, a| a[e] = object.public_send(e) }
-    "#{object} " << awesome_hash(data)
+    "#{object} #{awesome_hash(data)}"
   end
 
   # Format Cistern::Model
   #------------------------------------------------------------------------------
   def awesome_cistern_collection(object)
-    "#{object.class.name} " << awesome_hash(attributes: object.attributes, records: object.to_a)
+    "#{object.class.name} #{awesome_hash(attributes: object.attributes, records: object.to_a)}"
   end
 end
 

--- a/lib/cistern/formatter/default.rb
+++ b/lib/cistern/formatter/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cistern::Formatter::Default
   class << self
     def call(object)

--- a/lib/cistern/formatter/formatador.rb
+++ b/lib/cistern/formatter/formatador.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'formatador'
 
 module Cistern::Formatter::Formatador

--- a/lib/cistern/formatter/formatador.rb
+++ b/lib/cistern/formatter/formatador.rb
@@ -14,7 +14,7 @@ module Cistern::Formatter::Formatador
 
   def self.model_inspect(model)
     Thread.current[:formatador] ||= Formatador.new
-    data = "#{Thread.current[:formatador].indentation}<#{model.class.name}"
+    data = ["#{Thread.current[:formatador].indentation}<#{model.class.name}"]
     Thread.current[:formatador].indent do
       unless model.class.attributes.empty?
         data << "\n#{Thread.current[:formatador].indentation}"
@@ -22,12 +22,12 @@ module Cistern::Formatter::Formatador
       end
     end
     data << "\n#{Thread.current[:formatador].indentation}>"
-    data
+    data.join
   end
 
   def self.collection_inspect(collection)
     Thread.current[:formatador] ||= Formatador.new
-    data = "#{Thread.current[:formatador].indentation}<#{collection.class.name}\n"
+    data = ["#{Thread.current[:formatador].indentation}<#{collection.class.name}\n"]
     Thread.current[:formatador].indent do
       unless collection.class.attributes.empty?
         data << "#{Thread.current[:formatador].indentation}"
@@ -46,7 +46,7 @@ module Cistern::Formatter::Formatador
       data << "]\n"
     end
     data << "#{Thread.current[:formatador].indentation}>"
-    data
+    data.join
   end
 
   def table(attributes = nil)

--- a/lib/cistern/hash.rb
+++ b/lib/cistern/hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Cistern::Hash
   # @example
   #   Cistern::Hash.slice({ :a => 1, :b => 2 }, :a) #=> { :a => 1 }

--- a/lib/cistern/hash_support.rb
+++ b/lib/cistern/hash_support.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cistern::HashSupport
   def hash_slice(*args); Cistern::Hash.slice(*args); end
   def hash_except(*args); Cistern::Hash.except(*args); end

--- a/lib/cistern/mock.rb
+++ b/lib/cistern/mock.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cistern
   class Mock
     def self.not_implemented(method = '')

--- a/lib/cistern/model.rb
+++ b/lib/cistern/model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cistern::Model
   include Cistern::Attributes::InstanceMethods
   include Cistern::HashSupport

--- a/lib/cistern/request.rb
+++ b/lib/cistern/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cistern::Request
   include Cistern::HashSupport
 

--- a/lib/cistern/service.rb
+++ b/lib/cistern/service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Cistern::Service
   def self.inherited(klass)
     Cistern.deprecation(

--- a/lib/cistern/singular.rb
+++ b/lib/cistern/singular.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cistern::Singular
   include Cistern::Model
 

--- a/lib/cistern/string.rb
+++ b/lib/cistern/string.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Cistern::String
   def self.camelize(string)
     string.gsub(/[A-Z]+/) { |w| "_#{w.downcase}" }.gsub(/^_/, '')

--- a/lib/cistern/timeout.rb
+++ b/lib/cistern/timeout.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cistern
   module WaitFor
     def self.wait_for(timeout = Cistern.timeout, interval = Cistern.poll_interval, &_block)

--- a/lib/cistern/version.rb
+++ b/lib/cistern/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cistern
   VERSION = '2.8.0'
 end

--- a/lib/cistern/wait_for.rb
+++ b/lib/cistern/wait_for.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'timeout'
 
 module Cistern

--- a/spec/associations_spec.rb
+++ b/spec/associations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cistern::Associations do

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cistern::Attributes, '#clone_attributes' do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'client' do

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'Cistern::Collection' do

--- a/spec/coverage_spec.rb
+++ b/spec/coverage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'coverage', :coverage do

--- a/spec/dirty_spec.rb
+++ b/spec/dirty_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'Cistern::Model#dirty' do

--- a/spec/formatter_spec.rb
+++ b/spec/formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 class Inspector < Sample::Model

--- a/spec/hash_spec.rb
+++ b/spec/hash_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'Cistern::Hash' do

--- a/spec/mock_data_spec.rb
+++ b/spec/mock_data_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'mock data' do

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'Cistern::Model' do

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'Cistern::Request' do

--- a/spec/singular_spec.rb
+++ b/spec/singular_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'Cistern::Singular' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if ENV.key?('COVERAGE')
   require 'simplecov'
   SimpleCov.start

--- a/spec/support/service.rb
+++ b/spec/support/service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.before(:each) {
     Object.send(:remove_const, :Sample) if Object.constants.include?(:Sample)

--- a/spec/wait_for_spec.rb
+++ b/spec/wait_for_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'Cistern::WaitFor' do


### PR DESCRIPTION
String literals frozen [will default in Ruby 3.0](https://bugs.ruby-lang.org/issues/8976).