### PR TITLE
Separates args from kwargs for Ruby 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,12 +613,12 @@ class Blog::GetPost
     [post_id, stringify_keys(parameters)]
   end
 
-  def _mock(*args)
-    mock(*setup(*args))
+  def _mock(*args, **kwargs)
+    mock(*setup(*args, **kwargs))
   end
 
   def _real(post_id, parameters)
-    real(*setup(*args))
+    real(*setup(*args, **kwargs))
   end
 end
 ```

--- a/lib/cistern/attributes.rb
+++ b/lib/cistern/attributes.rb
@@ -65,11 +65,11 @@ module Cistern::Attributes
       name_sym
     end
 
-    def identity(*args)
-      args.any? ? @identity = attribute(*args) : (@identity ||= parent_identity)
+    def identity(*args, **kwargs)
+      args.any? ? @identity = attribute(*args, **kwargs) : (@identity ||= parent_identity)
     end
 
-    def ignore_attributes(*args)
+    def ignore_attributes(*args, **kwargs)
       @ignored_attributes = args
     end
 
@@ -229,7 +229,7 @@ module Cistern::Attributes
     #
     # @raise [ArgumentError] if any requested attribute does not have a value
     # @return [Hash] of matching attributes
-    def requires(*args)
+    def requires(*args, **kwargs)
       missing, required = missing_attributes(args)
 
       if missing.length == 1
@@ -245,7 +245,7 @@ module Cistern::Attributes
     #
     # @raise [ArgumentError] if no requested attributes have values
     # @return [Hash] of matching attributes
-    def requires_one(*args)
+    def requires_one(*args, **kwargs)
       missing, required = missing_attributes(args)
 
       if missing.length == args.length

--- a/lib/cistern/client.rb
+++ b/lib/cistern/client.rb
@@ -248,11 +248,11 @@ module Cistern::Client
       @_requests ||= []
     end
 
-    def requires(*args)
+    def requires(*args, **kwargs)
       required_arguments.concat(args)
     end
 
-    def recognizes(*args)
+    def recognizes(*args, **kwargs)
       recognized_arguments.concat(args)
     end
 

--- a/lib/cistern/data.rb
+++ b/lib/cistern/data.rb
@@ -30,7 +30,7 @@ module Cistern::Data
       data.clear
     end
 
-    def store_in(*args)
+    def store_in(*args, **kwargs)
       @storage = *args
       @data    = nil
     end

--- a/lib/cistern/hash_support.rb
+++ b/lib/cistern/hash_support.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Cistern::HashSupport
-  def hash_slice(*args); Cistern::Hash.slice(*args); end
-  def hash_except(*args); Cistern::Hash.except(*args); end
-  def hash_except!(*args); Cistern::Hash.except!(*args); end
-  def hash_stringify_keys(*args); Cistern::Hash.stringify_keys(*args); end
+  def hash_slice(*args, **kwargs); Cistern::Hash.slice(*args, **kwargs); end
+  def hash_except(*args, **kwargs); Cistern::Hash.except(*args, **kwargs); end
+  def hash_except!(*args, **kwargs); Cistern::Hash.except!(*args, **kwargs); end
+  def hash_stringify_keys(*args, **kwargs); Cistern::Hash.stringify_keys(*args, **kwargs); end
 end

--- a/lib/cistern/request.rb
+++ b/lib/cistern/request.rb
@@ -24,8 +24,8 @@ module Cistern::Request
     end
 
     method = <<-EOS
-      def #{name}(*args)
-        #{klass}.new(self).call(*args)
+      def #{name}(*args, **kwargs)
+        #{klass}.new(self).call(*args, **kwargs)
       end
     EOS
 
@@ -34,12 +34,12 @@ module Cistern::Request
     cistern::Real.module_eval method, __FILE__, __LINE__
   end
 
-  def self.service_request(*args)
+  def self.service_request(*args, **kwargs)
     Cistern.deprecation(
       '#service_request is deprecated.  Please use #cistern_request',
       caller[0]
     )
-    cistern_request(*args)
+    cistern_request(*args, **kwargs)
   end
 
   attr_reader :cistern
@@ -56,8 +56,8 @@ module Cistern::Request
     @cistern = cistern
   end
 
-  def call(*args)
-    dispatch(*args)
+  def call(*args, **kwargs)
+    dispatch(*args, **kwargs)
   end
 
   def real(*)
@@ -71,7 +71,7 @@ module Cistern::Request
   protected
 
   # @fixme remove _{mock,real} methods and call {mock,real} directly before 3.0 release.
-  def dispatch(*args)
+  def dispatch(*args, **kwargs)
     to = cistern.mocking? ? :mock : :real
 
     legacy_method = :"_#{to}"
@@ -82,9 +82,9 @@ module Cistern::Request
         caller[0]
       )
 
-      public_send(legacy_method, *args)
+      public_send(legacy_method, *args, **kwargs)
     else
-      public_send(to, *args)
+      public_send(to, *args, **kwargs)
     end
   end
 end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -11,7 +11,7 @@ describe 'Cistern::Request' do
     Sample::Real.class_eval do
       attr_reader :service_args
 
-      def initialize(*args)
+      def initialize(*args, **kwargs)
         @service_args = args
       end
     end
@@ -30,11 +30,11 @@ describe 'Cistern::Request' do
 
   it 'calls the appropriate method' do
     class GetSamples < Sample::Request
-      def real(*args)
+      def real(*args, **kwargs)
         cistern.service_args + args + ['real']
       end
 
-      def mock(*args)
+      def mock(*args, **kwargs)
         args + ['mock']
       end
     end


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Resolves one of the main issues in https://github.com/lanej/cistern/issues/85 upgrade to Ruby 3.0 path.