### PR TITLE
Prepend 'cistern: self' when calling self.cistern_model

### DIFF
--- a/lib/cistern/model.rb
+++ b/lib/cistern/model.rb
@@ -14,7 +14,7 @@ module Cistern::Model
   def self.cistern_model(cistern, klass, name)
     cistern.const_get(:Collections).module_eval <<-EOS, __FILE__, __LINE__
       def #{name}(attributes={})
-    #{klass.name}.new(attributes.merge(cistern: self))
+    #{klass.name}.new({cistern: self}.merge(attributes))
       end
     EOS
   end


### PR DESCRIPTION
This will ensure that any attribute method that references cistern will have a non-nil value to reference in the method invocation.

Previously, if an attribute called cistern internally, cistern would be nil and cause a `NoMethodError`

To provide an example, if I have an attribute I've defined, `foo`, and I have a setter method `foo=` with the following definition:
```ruby
def foo=(bar)
  attributes[:foo] = cistern.baz
end
```

Then the previous behavior would result in:
```
NoMethodError:
       undefined method `baz' for nil:NilClass
```

By prepending `{cistern: self}`, this ensures cistern is always set first, avoiding the above. 